### PR TITLE
Use alternateLink for the PDF to avoid 400 errors

### DIFF
--- a/accounting/invoice/tests/test_tasks.py
+++ b/accounting/invoice/tests/test_tasks.py
@@ -99,7 +99,7 @@ class InvoiceApprovalRequestTestCase(TestCase):
         """ The invoice approval request email sent out every month contains proper information. """
         # Mock.
         pdf_path = 'https://drive.google.com/invoice.pdf'
-        mock_upload_to_google_drive.return_value = {'webContentLink': pdf_path}
+        mock_upload_to_google_drive.return_value = {'alternateLink': pdf_path}
         mock_to_pdf.return_value = pdf_path
 
         # Call.
@@ -158,7 +158,7 @@ class InvoiceFinalizationTestCase(TestCase):
         """ The invoice finalization email sent out every month contains proper information. """
         # Mock.
         pdf_path = 'https://drive.google.com/invoice.pdf'
-        mock_upload_to_google_drive.return_value = {'webContentLink': pdf_path}
+        mock_upload_to_google_drive.return_value = {'alternateLink': pdf_path}
         mock_to_pdf.return_value = pdf_path
 
         # Call.

--- a/accounting/invoice/utils.py
+++ b/accounting/invoice/utils.py
@@ -75,7 +75,7 @@ def upload_invoice_to_google_drive(invoice, draft_invoice=False):
         target_path=target_path,
         title=invoice.pdf_filename,
     )
-    invoice.pdf_path = file['webContentLink']
+    invoice.pdf_path = file['alternateLink']
     invoice.save()
 
 

--- a/accounting/transferwise/models.py
+++ b/accounting/transferwise/models.py
@@ -136,7 +136,7 @@ class TransferWiseBulkPayment(CommonModel, UuidModel, TransferWiseCsvMixin, Goog
                 title=self.csv_filename,
             )
             # We can't save this field because we're already in the save method, so set it and then update it directly.
-            self.csv_path = file['webContentLink']
+            self.csv_path = file['alternateLink']
             TransferWiseBulkPayment.objects.filter(pk=self.pk).update(csv_path=self.csv_path)
 
 

--- a/accounting/transferwise/tests/test_models.py
+++ b/accounting/transferwise/tests/test_models.py
@@ -139,7 +139,7 @@ class TransferWiseBulkPaymentTestCase(TestCase):
     def test_auto_upload_google_drive_on_save(self, mock_upload_to_google_drive):
         """ `upload_to_google_drive` is called when `auto_upload_google_drive_on_save` is checked. """
         csv_path = 'https://drive.google.com/bulk_payment.csv'
-        mock_upload_to_google_drive.return_value = {'webContentLink': csv_path}
+        mock_upload_to_google_drive.return_value = {'alternateLink': csv_path}
         self.bulk_payment.auto_upload_google_drive_on_save = True  # pylint: disable=invalid-name,useless-suppression
         self.bulk_payment.save()
         mock_upload_to_google_drive.assert_called_once()


### PR DESCRIPTION
When creating a PDF invoice, `webContentLink` provides a link that will show a 403 error when the user is signed in from a different account. The new link, `alternateLink`, can show an account chooser to switch to another account.